### PR TITLE
Childproof spammable doors

### DIFF
--- a/js/mandril.js
+++ b/js/mandril.js
@@ -43,12 +43,21 @@ const Cookie = (function() {
 
 // Snackbar interaction
 const Snackbar = (function() {
+    let snackbarTimeout = null;
+
     const notify = function(msg, seconds = 3) {
+        // Clear any previous timeout
+        if (snackbarTimeout !== null) {
+            clearTimeout(snackbarTimeout);
+        }
+
         let snackbar = document.getElementById("snackbar");
         snackbar.innerHTML = msg;
         snackbar.className = "show";
+
         // After `seconds` hide the snackbar
-        setTimeout(function() {
+        // Store timeout to cancel it if user is a child and spams the button
+        snackbarTimeout = setTimeout(function() {
             snackbar.className = snackbar.className.replace("show", "");
         }, seconds * 1000);
         return;

--- a/js/mandril.js
+++ b/js/mandril.js
@@ -47,9 +47,7 @@ const Snackbar = (function() {
 
     const notify = function(msg, seconds = 3) {
         // Clear any previous timeout
-        if (snackbarTimeout !== null) {
-            clearTimeout(snackbarTimeout);
-        }
+        if (snackbarTimeout !== null) clearTimeout(snackbarTimeout);
 
         let snackbar = document.getElementById("snackbar");
         snackbar.innerHTML = msg;


### PR DESCRIPTION
This PR fixes an issue where an user were able to spam an unavailable door, and it would queue up timeouts, meaning a sudden removal of any subsequent snackbar messages.