### PR TITLE
Fix for issue on erroneous subsequent views of achivements 

### DIFF
--- a/js/achievements.js
+++ b/js/achievements.js
@@ -356,7 +356,6 @@ const Achievements = (function () {
     // When the user clicks on <span> (x), close the modal
     let closeModal = function () {
       modal.style.display = "none";
-      modalBody.innerHTML = "";
       window.onclick = null;
       document.body.className = document.body.className.replace(
         "dialogIsOpen",


### PR DESCRIPTION
Fixes #41 

Wrongly removed the inner html modal on first close, causing subsequent appearances to not be able to locate content div.